### PR TITLE
rerank 추가 및 bm25 docs 메타데이터 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,11 @@ __pycache__/
 .env
 *.onnx
 *.sqlite3
-/src/retrieval/data/*.pkl
+!/src/retrieval/data/**
 /src/vectordb/chroma_db/**
 
 *.ipynb
-/src/retrieval/modules/__pycache__/**
+!/src/retrieval/modules/__pycache__/**
 *.csv
 *.json
 *.bin

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@ __pycache__/
 .env
 *.onnx
 *.sqlite3
-!/src/retrieval/data/**
-/src/vectordb/chroma_db/**
+!src/retrieval/data/**
+!src/vectordb/chroma_db/**
 
 *.ipynb
 !src/retrieval/modules/__pycache__/**
@@ -21,6 +21,7 @@ __pycache__/
 *.json
 *.bin
 *.pickle
+*.pkl
 # chroma_db/73246dd6-03fd-4558-b1b6-2926908b70c0/data_level0.bin
 
 /src/retrieval/data/**

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ __pycache__/
 /src/vectordb/chroma_db/**
 
 *.ipynb
-!/src/retrieval/modules/__pycache__/**
+!src/retrieval/modules/__pycache__/**
 *.csv
 *.json
 *.bin

--- a/src/retrieval/modules/bm25_docs_generate.py
+++ b/src/retrieval/modules/bm25_docs_generate.py
@@ -4,7 +4,7 @@ import pickle
 import re
 from langchain_core.documents import Document
 
-chunk_dir = "/home/gcp-JeOn/Smash-RFP/data/dummy/"
+chunk_dir = "/home/gcp-JeOn/Smash-RFP/data/dummy_r_1000_100"
 output_path = "../data/bm25_docs.pkl"
 os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
@@ -22,25 +22,47 @@ for filename in os.listdir(chunk_dir):
     if not filename.endswith(".json"):
         continue
     filepath = os.path.join(chunk_dir, filename)
-    with open(filepath, "r", encoding="utf-8") as f:
-        data = json.load(f)
-        # case: {"chunks": [...]}
-        if isinstance(data, dict) and "chunks" in data:
-            for chunk in data["chunks"]:
-                # source_id를 normalize
-                raw_source_id = chunk.get("source_id") or filename
-                normalized_source_id = normalize_id(raw_source_id)
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            data = json.load(f)
 
+        # chunks가 없거나 형식이 이상하면 skip
+        chunks = data.get("chunks", [])
+        if not isinstance(chunks, list):
+            print(f"{filename} 처리 실패: 'chunks'가 list 형식이 아님")
+            continue
+
+        for i, chunk in enumerate(chunks):
+            # 문자열 청크 처리
+            if isinstance(chunk, str):
+                bm25_docs.append(Document(
+                    page_content=chunk,
+                    metadata={
+                        "source": data.get("filename", filename),
+                        "chunk_id": str(i),
+                        "source_id": normalize_id(data.get("source_id", filename)),
+                    }
+                ))
+            # dict 청크 처리
+            elif isinstance(chunk, dict):
                 bm25_docs.append(Document(
                     page_content=chunk.get("text", ""),
                     metadata={
-                        "chunk_id": chunk.get("chunk_id", ""),
-                        "source_id": normalized_source_id
+                        "source": data.get("filename", filename),
+                        "chunk_id": chunk.get("chunk_id", str(i)),
+                        "source_id": normalize_id(chunk.get("source_id", data.get("source_id", filename))),
                     }
                 ))
+            else:
+                print(f"{filename} - 알 수 없는 chunk 타입: {type(chunk)} → 무시됨")
+        
+        print(f"{filename} 처리 완료")
+
+    except Exception as e:
+        print(f"{filename} 처리 실패: {e}")
 
 # 저장
 with open(output_path, "wb") as f:
     pickle.dump(bm25_docs, f)
 
-print(f"{len(bm25_docs)}개의 청크가 저장되었습니다 → {output_path}")
+print(f"\n총 {len(bm25_docs)}개의 Document 객체가 저장되었습니다 → {output_path}")


### PR DESCRIPTION
## rerank 실험 결과 
- BM25 + CrossEncoder기반 rerank 버전이 가장 성능이 괜찮았습니다.
- top k = 3, 5

## 메타데이터 수정
BM25용 문서 생성하는 파일부터 재생성 해주세요.
파일명은 metadata내의 "source"로 정의함.